### PR TITLE
Make Entry.Size and ChunkUploadResponse.Offset be int64 - fixes #19

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -199,7 +199,7 @@ func (db *Dropbox) DownloadAES(key []byte, src, rev string, offset int) (io.Read
 	var size int64
 	var err error
 
-	if in, size, err = db.Download(src, rev, offset); err != nil {
+	if in, size, err = db.Download(src, rev, int64(offset)); err != nil {
 		return nil, err
 	}
 	return NewAESDecrypterReader(key, in, int(size))

--- a/dropbox.go
+++ b/dropbox.go
@@ -88,7 +88,7 @@ type DeltaPoll struct {
 // ChunkUploadResponse represents the reply of chunked_upload.
 type ChunkUploadResponse struct {
 	UploadID string `json:"upload_id"` // Unique ID of this upload.
-	Offset   int    `json:"offset"`    // Size in bytes of already sent data.
+	Offset   int64  `json:"offset"`    // Size in bytes of already sent data.
 	Expires  DBTime `json:"expires"`   // Expiration time of this upload.
 }
 
@@ -166,7 +166,7 @@ type Modifier struct {
 
 // Entry represents the metadata of a file or folder.
 type Entry struct {
-	Bytes                int       `json:"bytes,omitempty"`        // Size of the file in bytes.
+	Bytes                int64     `json:"bytes,omitempty"`        // Size of the file in bytes.
 	ClientMtime          DBTime    `json:"client_mtime,omitempty"` // Modification time set by the client when added.
 	Contents             []Entry   `json:"contents,omitempty"`     // List of children for a directory.
 	Hash                 string    `json:"hash,omitempty"`         // Hash of this entry.
@@ -572,7 +572,7 @@ func (db *Dropbox) ThumbnailsToFile(src, dst, format, size string) (*Entry, erro
 // Download requests the file located at src, the specific revision may be given.
 // offset is used in case the download was interrupted.
 // A io.ReadCloser and the file size is returned.
-func (db *Dropbox) Download(src, rev string, offset int) (io.ReadCloser, int64, error) {
+func (db *Dropbox) Download(src, rev string, offset int64) (io.ReadCloser, int64, error) {
 	var request *http.Request
 	var response *http.Response
 	var rawurl string
@@ -613,7 +613,7 @@ func (db *Dropbox) DownloadToFileResume(src, dst, rev string) error {
 	var input io.ReadCloser
 	var fi os.FileInfo
 	var fd *os.File
-	var offset int
+	var offset int64
 	var err error
 
 	if fd, err = os.OpenFile(dst, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644); err != nil {
@@ -623,7 +623,7 @@ func (db *Dropbox) DownloadToFileResume(src, dst, rev string) error {
 	if fi, err = fd.Stat(); err != nil {
 		return err
 	}
-	offset = int(fi.Size())
+	offset = fi.Size()
 
 	if input, _, err = db.Download(src, rev, offset); err != nil {
 		return err

--- a/dropbox_test.go
+++ b/dropbox_test.go
@@ -316,7 +316,7 @@ func TestFilesPut(t *testing.T) {
 	filename = "test.txt"
 	content = []byte("file content")
 
-	expected := Entry{Size: strconv.FormatInt(int64(len(content)), 10), Revision: "35e97029684fe", ThumbExists: false, Bytes: len(content),
+	expected := Entry{Size: strconv.FormatInt(int64(len(content)), 10), Revision: "35e97029684fe", ThumbExists: false, Bytes: int64(len(content)),
 		Modified: DBTime(time.Date(2011, time.July, 19, 21, 55, 38, 0, time.UTC)), Path: "/" + filename, IsDir: false, Icon: "page_white_text",
 		Root: "auto", MimeType: "text/plain"}
 


### PR DESCRIPTION
This allows the code to deal with files > 2 GB in size.  Previous to
this change a file > 2 GB would cause a JSON unmarshal error.

This is a breaking change to the API.  However the Go compiler will
throw errors at the right places when compiling so should be easy to
fix up the code.