### PR TITLE
Add SetOAuth2Config Function

### DIFF
--- a/dropbox.go
+++ b/dropbox.go
@@ -254,6 +254,11 @@ func (db *Dropbox) SetAppInfo(clientid, clientsecret string) error {
 	return nil
 }
 
+//SetOAuth2Config replaces the current oauth2.Config with an user provided one
+func (db *Dropbox) SetOAuth2Config(config *oauth2.Config) {
+	db.config = config
+}
+
 // SetAccessToken sets access token to avoid calling Auth method.
 func (db *Dropbox) SetAccessToken(accesstoken string) {
 	db.token = &oauth2.Token{AccessToken: accesstoken}


### PR DESCRIPTION
Adds the function SetOAuth2Config to the dropbox.go file. This would would ease if an user wants to use a different redirect URI for example