### PR TITLE
Remove extra / in Metadata request

### DIFF
--- a/dropbox.go
+++ b/dropbox.go
@@ -832,6 +832,7 @@ func (db *Dropbox) Metadata(src string, list bool, includeDeleted bool, hash, re
 		params.Set("hash", hash)
 	}
 
+	src = strings.Trim(src, "/")
 	act := strings.Join([]string{"metadata", db.RootDirectory, src}, "/")
 	err := db.doRequest("GET", act, params, &rv)
 	return &rv, err


### PR DESCRIPTION
This fixes the issuing of a request with a doubled slash in the URL.
This causes Dropbox to issue a 301 redirect to the URL without the
`//` which causes an extra HTTP transaction.