### PR TITLE
Added AuthURL function to allow web-based OAuth token exchange

### DIFF
--- a/dropbox.go
+++ b/dropbox.go
@@ -288,6 +288,12 @@ func (db *Dropbox) Auth() error {
 	return db.AuthCode(code)
 }
 
+// AuthURL returns the URL which must be visited to authorise this application.
+// Once authorised it will redirect to the URL set by SetRedirectURL
+func (db *Dropbox) AuthURL() string {
+	return db.config.AuthCodeURL("")
+}
+
 // AuthCode gets the token associated with the given code.
 func (db *Dropbox) AuthCode(code string) error {
 	t, err := db.config.Exchange(oauth2.NoContext, code)

--- a/dropbox.go
+++ b/dropbox.go
@@ -52,6 +52,7 @@ type Account struct {
 	DisplayName  string `json:"display_name,omitempty"`  // User name.
 	UID          int    `json:"uid,omitempty"`           // User account ID.
 	Country      string `json:"country,omitempty"`       // Country ISO code.
+	Email        string `json:"email,omitempty"`         // User E-Mail
 	QuotaInfo    struct {
 		Shared int64 `json:"shared,omitempty"` // Quota for shared files.
 		Quota  int64 `json:"quota,omitempty"`  // Quota in bytes.
@@ -252,6 +253,11 @@ func (db *Dropbox) SetAppInfo(clientid, clientsecret string) error {
 		},
 	}
 	return nil
+}
+
+//SetOAuth2Config replaces the current oauth2.Config with an user provided one
+func (db *Dropbox) SetOAuth2Config(config *oauth2.Config) {
+	db.config = config
 }
 
 // SetAccessToken sets access token to avoid calling Auth method.
@@ -689,8 +695,8 @@ func (db *Dropbox) doRequest(method, path string, params *url.Values, receiver i
 	return err
 }
 
-// GetAccountInfo gets account information for the user currently authenticated.
-func (db *Dropbox) GetAccountInfo() (*Account, error) {
+// AccountInfo gets account information for the user currently authenticated.
+func (db *Dropbox) AccountInfo() (*Account, error) {
 	var rv Account
 
 	err := db.doRequest("GET", "account/info", nil, &rv)

--- a/dropbox_test.go
+++ b/dropbox_test.go
@@ -143,7 +143,7 @@ func TestAccountInfo(t *testing.T) {
 		},
 	}
 
-	if received, err = db.GetAccountInfo(); err != nil {
+	if received, err = db.AccountInfo(); err != nil {
 		t.Errorf("API error: %s", err)
 	} else if !reflect.DeepEqual(expected, *received) {
 		t.Errorf("got %#v expected %#v", *received, expected)


### PR DESCRIPTION
Added ability to perform OAuth token exchange for web-based apps.

Example code:
To redirect to ask for authorisation:
```
db.SetRedirectURL(callback_url)
redirectUrl := db.AuthURL();
http.Redirect(w, r, redirectUrl, 302)
```
Then the redirectUrl will receive the request with the code as a query param:
```
code := r.URL.Query().Get("code")
```